### PR TITLE
Re-Apply our patches on top of upstream v1.3.5

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ binaries/proxysql-${CURVER}-1-centos5.x86_64.rpm:
 	docker cp docker/images/proxysql/centos5-build/proxysql.spec centos5_build:/root/rpmbuild/SPECS/proxysql.spec
 	sleep 2
 	docker exec -it centos5_build bash -c "cp /opt/proxysql/proxysql-${CURVER}.tar.gz /root/rpmbuild/SOURCES"
-	docker exec -it centos5_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec"
+	docker exec -it centos5_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec --define \"version ${CURVER}\""
 	sleep 2
 	docker exec -it centos5_build bash -c "cp /root/rpmbuild/RPMS/x86_64/proxysql-${CURVER}-1.x86_64.rpm /root/rpm"
 	sleep 2
@@ -146,7 +146,7 @@ binaries/proxysql-${CURVER}-1-dbg-centos5.x86_64.rpm:
 	docker cp docker/images/proxysql/centos5-build/proxysql.spec centos5_build:/root/rpmbuild/SPECS/proxysql.spec
 	sleep 2
 	docker exec -it centos5_build bash -c "cp /opt/proxysql/proxysql-${CURVER}.tar.gz /root/rpmbuild/SOURCES"
-	docker exec -it centos5_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec"
+	docker exec -it centos5_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec --define \"version ${CURVER}\""
 	sleep 2
 	docker exec -it centos5_build bash -c "cp /root/rpmbuild/RPMS/x86_64/proxysql-${CURVER}-1.x86_64.rpm /root/rpm"
 	sleep 2
@@ -167,7 +167,7 @@ binaries/proxysql-${CURVER}-1-centos67.x86_64.rpm:
 	docker cp docker/images/proxysql/centos67-build/proxysql.spec centos67_build:/root/rpmbuild/SPECS/proxysql.spec
 	sleep 2
 	docker exec -it centos67_build bash -c "cp /opt/proxysql/proxysql-${CURVER}.tar.gz /root/rpmbuild/SOURCES"
-	docker exec -it centos67_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec"
+	docker exec -it centos67_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec --define \"version ${CURVER}\""
 	sleep 2
 	docker exec -it centos67_build bash -c "cp /root/rpmbuild/RPMS/x86_64/proxysql-${CURVER}-1.x86_64.rpm /root/rpm"
 	sleep 2
@@ -188,7 +188,7 @@ binaries/proxysql-${CURVER}-1-dbg-centos67.x86_64.rpm:
 	docker cp docker/images/proxysql/centos67-build/proxysql.spec centos67_build:/root/rpmbuild/SPECS/proxysql.spec
 	sleep 2
 	docker exec -it centos67_build bash -c "cp /opt/proxysql/proxysql-${CURVER}.tar.gz /root/rpmbuild/SOURCES"
-	docker exec -it centos67_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec"
+	docker exec -it centos67_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec --define \"version ${CURVER}\""
 	sleep 2
 	docker exec -it centos67_build bash -c "cp /root/rpmbuild/RPMS/x86_64/proxysql-${CURVER}-1.x86_64.rpm /root/rpm"
 	sleep 2
@@ -209,7 +209,7 @@ binaries/proxysql-${CURVER}-1-centos7.x86_64.rpm:
 	docker cp docker/images/proxysql/centos7-build/proxysql.spec centos7_build:/root/rpmbuild/SPECS/proxysql.spec
 	sleep 2
 	docker exec -it centos7_build bash -c "cp /opt/proxysql/proxysql-${CURVER}.tar.gz /root/rpmbuild/SOURCES"
-	docker exec -it centos7_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec"
+	docker exec -it centos7_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec --define \"version ${CURVER}\""
 	sleep 2
 	docker exec -it centos7_build bash -c "cp /root/rpmbuild/RPMS/x86_64/proxysql-${CURVER}-1.x86_64.rpm /root/rpm"
 	sleep 2
@@ -230,7 +230,7 @@ binaries/proxysql-${CURVER}-1-dbg-centos7.x86_64.rpm:
 	docker cp docker/images/proxysql/centos7-build/proxysql.spec centos7_build:/root/rpmbuild/SPECS/proxysql.spec
 	sleep 2
 	docker exec -it centos7_build bash -c "cp /opt/proxysql/proxysql-${CURVER}.tar.gz /root/rpmbuild/SOURCES"
-	docker exec -it centos7_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec"
+	docker exec -it centos7_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec --define \"version ${CURVER}\""
 	sleep 2
 	docker exec -it centos7_build bash -c "cp /root/rpmbuild/RPMS/x86_64/proxysql-${CURVER}-1.x86_64.rpm /root/rpm"
 	sleep 2
@@ -252,7 +252,7 @@ binaries/proxysql-${CURVER}-1-fedora24.x86_64.rpm:
 	docker cp docker/images/proxysql/fedora24-build/proxysql.spec fedora24_build:/root/rpmbuild/SPECS/proxysql.spec
 	sleep 2
 	docker exec -it fedora24_build bash -c "cp /opt/proxysql/proxysql-${CURVER}.tar.gz /root/rpmbuild/SOURCES"
-	docker exec -it fedora24_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec"
+	docker exec -it fedora24_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec --define \"version ${CURVER}\""
 	sleep 2
 	docker exec -it fedora24_build bash -c "cp /root/rpmbuild/RPMS/x86_64/proxysql-${CURVER}-1.x86_64.rpm /root/rpm"
 	sleep 2
@@ -273,7 +273,7 @@ binaries/proxysql-${CURVER}-1-dbg-fedora24.x86_64.rpm:
 	docker cp docker/images/proxysql/fedora24-build/proxysql.spec fedora24_build:/root/rpmbuild/SPECS/proxysql.spec
 	sleep 2
 	docker exec -it fedora24_build bash -c "cp /opt/proxysql/proxysql-${CURVER}.tar.gz /root/rpmbuild/SOURCES"
-	docker exec -it fedora24_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec"
+	docker exec -it fedora24_build bash -c "cd /root/rpmbuild; rpmbuild -ba SPECS/proxysql.spec --define \"version ${CURVER}\""
 	sleep 2
 	docker exec -it fedora24_build bash -c "cp /root/rpmbuild/RPMS/x86_64/proxysql-${CURVER}-1.x86_64.rpm /root/rpm"
 	sleep 2

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ DEBUG=${ALL_DEBUG}
 #export DEBUG
 #export OPTZ
 #export EXTRALINK
-CURVER=1.3.5
+CURVER?=1.3.4
 MAKEOPT="-j 8"
 DISTRO := $(shell gawk -F= '/^NAME/{print $$2}' /etc/os-release)
 ifeq ($(wildcard /usr/lib/systemd/system), /usr/lib/systemd/system)

--- a/Makefile
+++ b/Makefile
@@ -27,15 +27,15 @@ debug: build_deps_debug build_lib_debug build_src_debug
 
 .PHONY: build_deps
 build_deps:
-	cd deps && OPTZ="${O2}" DEBUG="" CC=${CC} CXX=${CXX} ${MAKE}
+	cd deps && OPTZ="${O2}" DEBUG="-ggdb" CC=${CC} CXX=${CXX} ${MAKE}
 
 .PHONY: build_lib
 build_lib: build_deps
-	cd lib && OPTZ="${O2}" DEBUG="" CC=${CC} CXX=${CXX} ${MAKE}
+	cd lib && OPTZ="${O2}" DEBUG="-ggdb" CC=${CC} CXX=${CXX} ${MAKE}
 
 .PHONY: build_src
 build_src: build_deps build_lib
-	cd src && OPTZ="${O2}" DEBUG="" CC=${CC} CXX=${CXX} ${MAKE}
+	cd src && OPTZ="${O2}" DEBUG="-ggdb" CC=${CC} CXX=${CXX} ${MAKE}
 
 .PHONY: build_deps_debug
 build_deps_debug:

--- a/Makefile
+++ b/Makefile
@@ -27,27 +27,27 @@ debug: build_deps_debug build_lib_debug build_src_debug
 
 .PHONY: build_deps
 build_deps:
-	cd deps && OPTZ="${O2}" CC=${CC} CXX=${CXX} ${MAKE}
+	cd deps && OPTZ="${O2}" DEBUG="" CC=${CC} CXX=${CXX} ${MAKE}
 
 .PHONY: build_lib
 build_lib: build_deps
-	cd lib && OPTZ="${O2}" CC=${CC} CXX=${CXX} ${MAKE}
+	cd lib && OPTZ="${O2}" DEBUG="" CC=${CC} CXX=${CXX} ${MAKE}
 
 .PHONY: build_src
 build_src: build_deps build_lib
-	cd src && OPTZ="${O2}" CC=${CC} CXX=${CXX} ${MAKE}
+	cd src && OPTZ="${O2}" DEBUG="" CC=${CC} CXX=${CXX} ${MAKE}
 
 .PHONY: build_deps_debug
 build_deps_debug:
-	cd deps && OPTZ="${O0} ${ALL_DEBUG}" CC=${CC} CXX=${CXX} ${MAKE}
+	cd deps && OPTZ="${O0}" DEBUG="${ALL_DEBUG}" CC=${CC} CXX=${CXX} ${MAKE}
 
 .PHONY: build_lib_debug
 build_lib_debug: build_deps_debug
-	cd lib && OPTZ="${O0} ${ALL_DEBUG}" CC=${CC} CXX=${CXX} ${MAKE}
+	cd lib && OPTZ="${O0}" DEBUG="${ALL_DEBUG}" CC=${CC} CXX=${CXX} ${MAKE}
 
 .PHONY: build_src_debug
 build_src_debug: build_deps build_lib_debug
-	cd src && OPTZ="${O0} ${ALL_DEBUG}" CC=${CC} CXX=${CXX} ${MAKE}
+	cd src && OPTZ="${O0}" DEBUG="${ALL_DEBUG}" CC=${CC} CXX=${CXX} ${MAKE}
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -27,27 +27,27 @@ debug: build_deps_debug build_lib_debug build_src_debug
 
 .PHONY: build_deps
 build_deps:
-	cd deps && OPTZ="${O2} -ggdb" CC=${CC} CXX=${CXX} ${MAKE}
+	cd deps && OPTZ="${O2}" CC=${CC} CXX=${CXX} ${MAKE}
 
 .PHONY: build_lib
 build_lib: build_deps
-	cd lib && OPTZ="${O2} -ggdb" CC=${CC} CXX=${CXX} ${MAKE}
+	cd lib && OPTZ="${O2}" CC=${CC} CXX=${CXX} ${MAKE}
 
 .PHONY: build_src
 build_src: build_deps build_lib
-	cd src && OPTZ="${O2} -ggdb" CC=${CC} CXX=${CXX} ${MAKE}
+	cd src && OPTZ="${O2}" CC=${CC} CXX=${CXX} ${MAKE}
 
 .PHONY: build_deps_debug
 build_deps_debug:
-	cd deps && OPTZ="${O0} -ggdb -DDEBUG" CC=${CC} CXX=${CXX} ${MAKE}
+	cd deps && OPTZ="${O0} ${ALL_DEBUG}" CC=${CC} CXX=${CXX} ${MAKE}
 
 .PHONY: build_lib_debug
 build_lib_debug: build_deps_debug
-	cd lib && OPTZ="${O0} -ggdb -DDEBUG" CC=${CC} CXX=${CXX} ${MAKE}
+	cd lib && OPTZ="${O0} ${ALL_DEBUG}" CC=${CC} CXX=${CXX} ${MAKE}
 
 .PHONY: build_src_debug
 build_src_debug: build_deps build_lib_debug
-	cd src && OPTZ="${O0} -ggdb -DDEBUG" CC=${CC} CXX=${CXX} ${MAKE}
+	cd src && OPTZ="${O0} ${ALL_DEBUG}" CC=${CC} CXX=${CXX} ${MAKE}
 
 .PHONY: clean
 clean:

--- a/docker/images/proxysql/centos5-build/proxysql.spec
+++ b/docker/images/proxysql/centos5-build/proxysql.spec
@@ -7,7 +7,7 @@
 
 Summary: A high-performance MySQL proxy
 Name: proxysql
-Version: 1.3.0h
+Version: %{version}
 Release: 1
 License: GPL+
 Group: Development/Tools

--- a/docker/images/proxysql/centos5-build/proxysql.spec
+++ b/docker/images/proxysql/centos5-build/proxysql.spec
@@ -1,0 +1,73 @@
+# Don't try fancy stuff like debuginfo, which is useless on binary-only
+# packages. Don't strip binary too
+# Be sure buildpolicy set to do nothing
+%define        __spec_install_post %{nil}
+%define          debug_package %{nil}
+%define        __os_install_post %{_dbpath}/brp-compress
+
+Summary: A high-performance MySQL proxy
+Name: proxysql
+Version: 1.3.0h
+Release: 1
+License: GPL+
+Group: Development/Tools
+SOURCE0 : %{name}-%{version}.tar.gz
+URL: http://www.proxysql.com/
+
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+
+%description
+%{summary}
+
+%prep
+%setup -q
+
+%build
+# Empty section.
+
+%install
+rm -rf %{buildroot}
+mkdir -p  %{buildroot}
+
+# in builddir
+cp -a * %{buildroot}
+
+%clean
+rm -rf %{buildroot}
+
+%post
+mkdir /var/run/%{name}
+chkconfig --add %{name}
+
+%postun
+rm -rf /var/run/%{name}
+chkconfig --del %{name}
+
+%files
+%defattr(-,root,root,-)
+%config(noreplace) %{_sysconfdir}/%{name}.cnf
+%{_bindir}/*
+%{_sysconfdir}/init.d/%{name}
+/usr/share/proxysql/tools/proxysql_galera_checker.sh
+/usr/share/proxysql/tools/proxysql_galera_writer.pl
+
+%changelog
+* Wed Oct 19 2016  Rene Cannao <rene.cannao@gmail.com> 1.3.0
+- experimental support for Prepared Statements
+- enhanced scalability
+* Thu Sep 29 2016  Rene Cannao <rene.cannao@gmail.com> 1.2.4
+- Forth stable release of 1.2
+* Tue Sep 20 2016  Rene Cannao <rene.cannao@gmail.com> 1.2.3
+- Third stable release of 1.2
+* Fri Sep 2 2016  Rene Cannao <rene.cannao@gmail.com> 1.2.2
+- Second stable release of 1.2
+* Tue Aug 2 2016  Rene Cannao <rene.cannao@gmail.com> 1.2.1
+- First stable release of 1.2
+* Mon Mar 14 2016 Rene Cannao <rene.cannao@gmail.com> 1.2.0
+- First testing release of 1.2
+* Sat Mar 11 2016 Rene Cannao <rene.cannao@gmail.com> 1.1.2
+- Upgraded to release 1.1.2
+* Sat Oct 31 2015 Rene Cannao <rene.cannao@gmail.com> 1.0.1
+- Compiles 1.0.1
+* Wed Sep 9 2015  Andrei Ismail <iandrei@gmail.com> 0.2
+- Added support for automatic packaging on Ubuntu 14.04 and CentOS 7.

--- a/docker/images/proxysql/centos5-build/proxysql.spec
+++ b/docker/images/proxysql/centos5-build/proxysql.spec
@@ -6,6 +6,7 @@
 %define        __os_install_post %{_dbpath}/brp-compress
 %define 	   _rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}.el5.%%{ARCH}.rpm
 %define          release 1.el5
+%define          dist el5
 
 Summary: A high-performance MySQL proxy
 Name: proxysql

--- a/docker/images/proxysql/centos5-build/proxysql.spec
+++ b/docker/images/proxysql/centos5-build/proxysql.spec
@@ -4,6 +4,7 @@
 %define        __spec_install_post %{nil}
 %define          debug_package %{nil}
 %define        __os_install_post %{_dbpath}/brp-compress
+%define 	   _rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}.el5.%%{ARCH}.rpm
 
 Summary: A high-performance MySQL proxy
 Name: proxysql

--- a/docker/images/proxysql/centos5-build/proxysql.spec
+++ b/docker/images/proxysql/centos5-build/proxysql.spec
@@ -5,11 +5,12 @@
 %define          debug_package %{nil}
 %define        __os_install_post %{_dbpath}/brp-compress
 %define 	   _rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}.el5.%%{ARCH}.rpm
+%define          release 1.el5
 
 Summary: A high-performance MySQL proxy
 Name: proxysql
 Version: %{version}
-Release: 1
+Release: %{release}
 License: GPL+
 Group: Development/Tools
 SOURCE0 : %{name}-%{version}.tar.gz

--- a/docker/images/proxysql/centos5-build/rpmmacros
+++ b/docker/images/proxysql/centos5-build/rpmmacros
@@ -1,0 +1,2 @@
+%_topdir   %(echo $HOME)/rpmbuild
+%_tmppath  %{_topdir}/tmp

--- a/docker/images/proxysql/centos67-build/proxysql.spec
+++ b/docker/images/proxysql/centos67-build/proxysql.spec
@@ -7,7 +7,7 @@
 
 Summary: A high-performance MySQL proxy
 Name: proxysql
-Version: 1.3.5
+Version: %{version}
 Release: 1
 License: GPL+
 Group: Development/Tools

--- a/docker/images/proxysql/centos67-build/proxysql.spec
+++ b/docker/images/proxysql/centos67-build/proxysql.spec
@@ -5,11 +5,12 @@
 %define          debug_package %{nil}
 %define        __os_install_post %{_dbpath}/brp-compress
 %define 	   _rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}.el6.%%{ARCH}.rpm
+%define          release 1.el6
 
 Summary: A high-performance MySQL proxy
 Name: proxysql
 Version: %{version}
-Release: 1
+Release: %{release}
 License: GPL+
 Group: Development/Tools
 SOURCE0 : %{name}-%{version}.tar.gz

--- a/docker/images/proxysql/centos67-build/proxysql.spec
+++ b/docker/images/proxysql/centos67-build/proxysql.spec
@@ -6,6 +6,7 @@
 %define        __os_install_post %{_dbpath}/brp-compress
 %define 	   _rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}.el6.%%{ARCH}.rpm
 %define          release 1.el6
+%define          dist el6
 
 Summary: A high-performance MySQL proxy
 Name: proxysql

--- a/docker/images/proxysql/centos67-build/proxysql.spec
+++ b/docker/images/proxysql/centos67-build/proxysql.spec
@@ -4,6 +4,7 @@
 %define        __spec_install_post %{nil}
 %define          debug_package %{nil}
 %define        __os_install_post %{_dbpath}/brp-compress
+%define 	   _rpmfilename %%{NAME}-%%{VERSION}-%%{RELEASE}.el6.%%{ARCH}.rpm
 
 Summary: A high-performance MySQL proxy
 Name: proxysql

--- a/docker/images/proxysql/centos7-build/proxysql.spec
+++ b/docker/images/proxysql/centos7-build/proxysql.spec
@@ -7,7 +7,7 @@
 
 Summary: A high-performance MySQL proxy
 Name: proxysql
-Version: 1.3.5
+Version: %{version}
 Release: 1
 License: GPL+
 Group: Development/Tools

--- a/docker/images/proxysql/centos7-build/proxysql.spec
+++ b/docker/images/proxysql/centos7-build/proxysql.spec
@@ -4,11 +4,12 @@
 %define        __spec_install_post %{nil}
 %define          debug_package %{nil}
 %define        __os_install_post %{_dbpath}/brp-compress
+%define          release 1.el7
 
 Summary: A high-performance MySQL proxy
 Name: proxysql
 Version: %{version}
-Release: 1
+Release: %{release}
 License: GPL+
 Group: Development/Tools
 SOURCE0 : %{name}-%{version}.tar.gz

--- a/docker/images/proxysql/centos7-build/proxysql.spec
+++ b/docker/images/proxysql/centos7-build/proxysql.spec
@@ -5,6 +5,7 @@
 %define          debug_package %{nil}
 %define        __os_install_post %{_dbpath}/brp-compress
 %define          release 1.el7
+%define          dist el7
 
 Summary: A high-performance MySQL proxy
 Name: proxysql

--- a/docker/images/proxysql/fedora24-build/proxysql.spec
+++ b/docker/images/proxysql/fedora24-build/proxysql.spec
@@ -7,7 +7,7 @@
 
 Summary: A high-performance MySQL proxy
 Name: proxysql
-Version: 1.3.5
+Version: %{version}
 Release: 1
 License: GPL+
 Group: Development/Tools

--- a/etc/init.d/proxysql
+++ b/etc/init.d/proxysql
@@ -1,5 +1,9 @@
 #!/bin/bash 
 #
+# chkconfig: 345 99 01
+# description: High Performance and Advanced Proxy for MySQL and forks. \
+# It provides advanced features like connection pool, query routing and rewrite, \
+# firewalling, throttling, real time analysis, error-free failover
 ### BEGIN INIT INFO
 # Provides:          proxysql
 # Required-Start:    $local_fs

--- a/lib/MySQL_Thread.cpp
+++ b/lib/MySQL_Thread.cpp
@@ -8,6 +8,12 @@
 MySQL_Session *sess_stopat;
 #endif
 
+#ifdef epoll_create1
+	#define EPOLL_CREATE epoll_create1(0)
+#else
+	#define EPOLL_CREATE epoll_create(1)
+#endif
+
 #define PROXYSQL_LISTEN_LEN 1024
 #define MIN_THREADS_FOR_MAINTENANCE 8
 
@@ -2006,7 +2012,7 @@ void MySQL_Thread::run() {
 	if (idle_maintenance_thread) {
 		// we check if it is the first time we are called
 		if (efd==-1) {
-			efd = epoll_create1(0);
+			efd = EPOLL_CREATE;
 			int fd=pipefd[0];
 			struct epoll_event event;
 			memset(&event,0,sizeof(event)); // let's make valgrind happy


### PR DESCRIPTION
This drops the patch from https://github.com/freshbooks/proxysql/commit/ae83dba176e50715dae54f04b0ada172fff25789 which should be fixed in 1.3.5